### PR TITLE
【Fix】ActionCableの記述削除

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -79,8 +79,6 @@ Rails.application.configure do
   # Only use :id for inspections in production.
   config.active_record.attributes_for_inspect = [ :id ]
 
-  config.solid_cable.enabled = false
-
   # Enable DNS rebinding protection and other `Host` header attacks.
   # config.hosts = [
   #   "example.com",     # Allow requests from example.com


### PR DESCRIPTION
## 概要
Renderでのデプロイ中にビルドエラー発生。
Gemfile読み込み前のaction_cableの指定が原因のようなので、環境ファイルでのメソッドを削除