### PR TITLE
【Fix】cacheやqueueのDBを定義

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -88,5 +88,14 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
+  primary:
+    url: <%= ENV["DATABASE_URL"] %>
+  cache:
+    url: <%= ENV["DATABASE_URL"] %>
+    migrations_paths: db/cache_migrate
+  queue:
+    url: <%= ENV["DATABASE_URL"] %>
+    migrations_paths: db/queue_migrate
+  cable:
+    url: <%= ENV["DATABASE_URL"] %>
+    migrations_paths: db/cable_migrate


### PR DESCRIPTION
## 概要
renderにてcacheなどのDB定義が無いことでBuild失敗のため、定義を追加