### PR TITLE
【Fix】【add】本番データ作成のための商品管理画面作成DB単一想定でsolid_queue用のテーブルを作成

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -18,14 +18,15 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: db
-  username: postgres
-  password: password
 
 
 development:
-  <<: *default
-  database: pro_log_development
+  primary: &development_primary
+    <<: *default
+    database: pro_log_development
+    host: db
+    username: postgres
+    password: password
 
   # The specified database role being used to connect to PostgreSQL.
   # To create additional roles in PostgreSQL see `$ createuser --help`.
@@ -60,6 +61,9 @@ development:
 test:
   <<: *default
   database: pro_log_test
+  host: db
+  username: postgres
+  password: password
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -88,14 +92,15 @@ test:
 # for a full overview on how database connection configuration can be specified.
 #
 production:
-  primary:
+  primary: &primary_production
+    <<: *default
     url: <%= ENV["DATABASE_URL"] %>
   cache:
-    url: <%= ENV["DATABASE_URL"] %>
+    <<: *primary_production
     migrations_paths: db/cache_migrate
   queue:
-    url: <%= ENV["DATABASE_URL"] %>
+    <<: *primary_production
     migrations_paths: db/queue_migrate
   cable:
-    url: <%= ENV["DATABASE_URL"] %>
+    <<: *primary_production
     migrations_paths: db/cable_migrate

--- a/db/queue_migrate/20251230024917_create_solid_queue_tables.rb
+++ b/db/queue_migrate/20251230024917_create_solid_queue_tables.rb
@@ -1,0 +1,131 @@
+class CreateSolidQueueTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :solid_queue_blocked_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.string :concurrency_key, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :created_at, null: false
+      t.index [ :concurrency_key, :priority, :job_id ], name: "index_solid_queue_blocked_executions_for_release"
+      t.index [ :expires_at, :concurrency_key ], name: "index_solid_queue_blocked_executions_for_maintenance"
+      t.index [ :job_id ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+    end
+
+    create_table :solid_queue_claimed_executions do |t|
+      t.bigint :job_id, null: false
+      t.bigint :process_id
+      t.datetime :created_at, null: false
+      t.index [ :job_id ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+      t.index [ :process_id, :job_id ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+    end
+
+    create_table :solid_queue_failed_executions do |t|
+      t.bigint :job_id, null: false
+      t.text :error
+      t.datetime :created_at, null: false
+      t.index [ :job_id ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+    end
+
+    create_table :solid_queue_jobs do |t|
+      t.string :queue_name, null: false
+      t.string :class_name, null: false
+      t.text :arguments
+      t.integer :priority, default: 0, null: false
+      t.string :active_job_id
+      t.datetime :scheduled_at
+      t.datetime :finished_at
+      t.string :concurrency_key
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index [ :active_job_id ], name: "index_solid_queue_jobs_on_active_job_id"
+      t.index [ :class_name ], name: "index_solid_queue_jobs_on_class_name"
+      t.index [ :finished_at ], name: "index_solid_queue_jobs_on_finished_at"
+      t.index [ :queue_name, :finished_at ], name: "index_solid_queue_jobs_for_filtering"
+      t.index [ :scheduled_at, :finished_at ], name: "index_solid_queue_jobs_for_alerting"
+    end
+
+    create_table :solid_queue_pauses do |t|
+      t.string :queue_name, null: false
+      t.datetime :created_at, null: false
+      t.index [ :queue_name ], name: "index_solid_queue_pauses_on_queue_name", unique: true
+    end
+
+    create_table :solid_queue_processes do |t|
+      t.string :kind, null: false
+      t.datetime :last_heartbeat_at, null: false
+      t.bigint :supervisor_id
+      t.integer :pid, null: false
+      t.string :hostname
+      t.text :metadata
+      t.datetime :created_at, null: false
+      t.string :name, null: false
+      t.index [ :last_heartbeat_at ], name: "index_solid_queue_processes_on_last_heartbeat_at"
+      t.index [ :name, :supervisor_id ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+      t.index [ :supervisor_id ], name: "index_solid_queue_processes_on_supervisor_id"
+    end
+
+    create_table :solid_queue_ready_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :created_at, null: false
+      t.index [ :job_id ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+      t.index [ :priority, :job_id ], name: "index_solid_queue_poll_all"
+      t.index [ :queue_name, :priority, :job_id ], name: "index_solid_queue_poll_by_queue"
+    end
+
+    create_table :solid_queue_recurring_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :task_key, null: false
+      t.datetime :run_at, null: false
+      t.datetime :created_at, null: false
+      t.index [ :job_id ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+      t.index [ :task_key, :run_at ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+    end
+
+    create_table :solid_queue_recurring_tasks do |t|
+      t.string :key, null: false
+      t.string :schedule, null: false
+      t.string :command, limit: 2048
+      t.string :class_name
+      t.text :arguments
+      t.string :queue_name
+      t.integer :priority, default: 0
+      t.boolean :static, default: true, null: false
+      t.text :description
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index [ :key ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+      t.index [ :static ], name: "index_solid_queue_recurring_tasks_on_static"
+    end
+
+    create_table :solid_queue_scheduled_executions do |t|
+      t.bigint :job_id, null: false
+      t.string :queue_name, null: false
+      t.integer :priority, default: 0, null: false
+      t.datetime :scheduled_at, null: false
+      t.datetime :created_at, null: false
+      t.index [ :job_id ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+      t.index [ :scheduled_at, :priority, :job_id ], name: "index_solid_queue_dispatch_all"
+    end
+
+    create_table :solid_queue_semaphores do |t|
+      t.string :key, null: false
+      t.integer :value, default: 1, null: false
+      t.datetime :expires_at, null: false
+      t.datetime :created_at, null: false
+      t.datetime :updated_at, null: false
+      t.index [ :expires_at ], name: "index_solid_queue_semaphores_on_expires_at"
+      t.index [ :key, :value ], name: "index_solid_queue_semaphores_on_key_and_value"
+      t.index [ :key ], name: "index_solid_queue_semaphores_on_key", unique: true
+    end
+
+    add_foreign_key :solid_queue_blocked_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_claimed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_failed_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_ready_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_recurring_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+    add_foreign_key :solid_queue_scheduled_executions, :solid_queue_jobs, column: :job_id, on_delete: :cascade
+  end
+end


### PR DESCRIPTION
#### 見積もり（調査した作業内容） 8h/1人日
- [x] database.ymlの修正(0.03人日)
- [x] solid_queue用のテーブルを作成＋マイグレーション(0.06人日)

合計0.09人日　約0.75h

#### 参考資料
  - https://github.com/rails/solid_queue
  - https://briancasel.gitbook.io/cheatsheet/rails-1/setup-solid-queue-cable-cache-in-rails-8-to-share-a-single-database

#### 気になっている点/イメージの不明な点
  - 特になし