### PR TITLE
【Fix】【bugfix】共有文言とメタタグの編集

### DIFF
--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,10 +1,21 @@
 <% content_for :head do %>
+  <% review_title = @review.title %>
+  <% review_description = t("reviews.show.og_description", product: @review.product.name) %>
+  <% review_url_value = review_url(@review) %>
+  <% og_image_url = image_url("ogp.png") %>
+
   <meta property="og:type" content="article">
-  <meta property="og:title" content="<%= @review.title %>">
-  <meta property="og:description" content="<%= t("reviews.show.og_description", product: @review.product.name) %>">
-  <meta property="og:url" content="<%= request.original_url %>">
-  <meta property="og:image" content="<%= image_url("ogp.png") %>">
+  <meta property="og:title" content="<%= review_title %>">
+  <meta property="og:description" content="<%= review_description %>">
+  <meta property="og:url" content="<%= review_url_value %>">
+  <meta property="og:image" content="<%= og_image_url %>">
+  <meta property="og:image:secure_url" content="<%= og_image_url %>">
+  <meta property="og:image:type" content="image/png">
+  <meta property="og:site_name" content="Pro-log">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="<%= review_title %>">
+  <meta name="twitter:description" content="<%= review_description %>">
+  <meta name="twitter:image" content="<%= og_image_url %>">
 <% end %>
 
 <main class="min-h-screen bg-white text-main">
@@ -28,7 +39,7 @@
             blanks: "☆" * (5 - @review.overall_score),
             score: score_text,
             username: @review.user.username)) %>
-          <% share_url = ERB::Util.url_encode(request.original_url) %>
+          <% share_url = ERB::Util.url_encode(review_url(@review)) %>
           <%= link_to "https://twitter.com/intent/tweet?text=#{share_text}&url=#{share_url}",
             target: "_blank",
             rel: "noopener",
@@ -93,9 +104,8 @@
                   stars: "★" * @review.overall_score,
                   blanks: "☆" * (5 - @review.overall_score),
                   score: score_text,
-                  username: @review.user.username,
-                  root_url: root_url)) %>
-                <% share_url = ERB::Util.url_encode(request.original_url) %>
+                  username: @review.user.username)) %>
+                <% share_url = ERB::Util.url_encode(review_url(@review)) %>
                 <%= link_to "https://twitter.com/intent/tweet?text=#{share_text}&url=#{share_url}",
                   target: "_blank",
                   rel: "noopener",

--- a/config/locales/reviews.ja.yml
+++ b/config/locales/reviews.ja.yml
@@ -80,7 +80,7 @@ ja:
         later: "あとで"
         cta: "Xでシェア"
         tweet: "%{brand}の%{product}を飲んだ感想を投稿しました。\n\n満足度：%{stars}%{blanks}（%{score}/5.0）\n\nPro-logで%{username}さんのプロテインレビューを見よう！\n\n#プロテインレビュー #%{brand} #プロテイン"
-        tweet_short: "%{brand}の%{product}を飲んだ感想を投稿しました。\n満足度：%{stars}%{blanks}（%{score}/5.0）\nPro-log(%{root_url})で%{username}さんのプロテインレビューを見る。\n#プロテインレビュー #%{brand} #プロテイン"
+        tweet_short: "%{brand}の%{product}を飲んだ感想を投稿しました。\n満足度：%{stars}%{blanks}（%{score}/5.0）\nPro-logで%{username}さんのプロテインレビューを見る。\n#プロテインレビュー #%{brand} #プロテイン"
       actions:
         edit: "編集"
         delete: "削除"


### PR DESCRIPTION
## 概要
X投稿時にまだ画像が表示されなかったため修正

### 原因
- メタタグの不足
- 共有文に余計なリンクが別にあったため

### 対応
- メタタグの追加
- 共有文から不要なリンクの削除