### PR TITLE
【fix】【bugfix】スレッド数指定

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -17,7 +17,7 @@ default: &default
   encoding: unicode
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
-  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 2 } %>
+  pool: <%= ENV.fetch("DB_POOL") { 5 } %>
 
 
 development:


### PR DESCRIPTION
## 概要
インスタンスのメモリー不足が頻繁に起きるため、SolidQueueは別出しの予定
一旦スレッド数はDBのプール数に合わせる