### PR TITLE
【Fix】【update】パスワードの入力ポリシーを予め伝えるメッセージを追加

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -14,6 +14,7 @@
           <% if @minimum_password_length %>
             <p class="mt-1 text-xs text-stone-400"><%= t("devise.views.passwords.edit.password_hint", count: @minimum_password_length) %></p>
           <% end %>
+          <p class="mt-1 text-xs text-stone-400"><%= t("devise.views.passwords.edit.password_policy_hint") %></p>
           <%= f.password_field :password, autocomplete: "new-password", class: "mt-2 w-full rounded-lg border border-base bg-white px-4 py-3 text-sm text-main focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand-light/30" %>
         </div>
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -51,6 +51,10 @@
       <div class="mb-6">
         <%= f.label :password, t("devise.views.registrations.edit.password_label"),
           class: "mb-2 block text-sm font-semibold text-stone-700" %>
+        <% if @minimum_password_length %>
+          <p class="mt-1 text-xs text-stone-400"><%= t("devise.views.registrations.new.password_hint", count: @minimum_password_length) %></p>
+        <% end %>
+        <p class="mb-2 text-xs text-stone-400"><%= t("devise.views.registrations.edit.password_policy_hint") %></p>
         <%= f.password_field :password,
           autocomplete: "new-password",
           class: "w-full rounded-lg border border-base px-4 py-3" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -27,6 +27,7 @@
           <% if @minimum_password_length %>
             <p class="mt-1 text-xs text-stone-400"><%= t("devise.views.registrations.new.password_hint", count: @minimum_password_length) %></p>
           <% end %>
+          <p class="mt-1 text-xs text-stone-400"><%= t("devise.views.registrations.new.password_policy_hint") %></p>
           <%= f.password_field :password, autocomplete: "new-password", class: "mt-2 w-full rounded-lg border border-base bg-white px-4 py-3 text-sm text-main focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand-light/30" %>
         </div>
 

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -78,6 +78,7 @@ ja:
           email_label: "メールアドレス"
           password_label: "パスワード"
           password_hint: "最低 %{count} 文字"
+          password_policy_hint: "半角英大文字・英小文字・数字をそれぞれ1文字以上含めてください。"
           password_confirmation_label: "パスワード確認"
           submit: "登録する"
           omniauth_title: "Googleアカウントで簡単登録"
@@ -96,6 +97,7 @@ ja:
           password_section_title: "パスワード変更"
           current_password_label: "現在のパスワード"
           password_label: "新しいパスワード"
+          password_policy_hint: "半角英大文字・英小文字・数字をそれぞれ1文字以上含めてください。"
           password_confirmation_label: "新しいパスワード（確認）"
           submit: "変更内容を保存する"
           back_to_profile: "プロフィールに戻る"
@@ -111,6 +113,7 @@ ja:
           subtitle: "新しいパスワードを入力してください。"
           password_label: "新しいパスワード"
           password_hint: "最低 %{count} 文字"
+          password_policy_hint: "半角英大文字・英小文字・数字をそれぞれ1文字以上含めてください。"
           password_confirmation_label: "新しいパスワード（確認）"
           submit: "パスワードを更新"
       confirmations:


### PR DESCRIPTION
## 概要
パスワードの作成、変更時にパスワードに必要な文字についてフォームの上に表示するよう文言追加。
ユーザーの入力ストレスを減らす意図